### PR TITLE
feat: add defaultPageSize to make pagesize to be  controled

### DIFF
--- a/packages/antd-materials/lowcode/pro-table/meta.ts
+++ b/packages/antd-materials/lowcode/pro-table/meta.ts
@@ -626,10 +626,23 @@ const ProTableMeta = {
               setValue: (target, value) => {
                 if (value) {
                   target.parent.setPropValue('pagination', {
-                    pageSize: 10
+                    defaultPageSize: 10
                   })
                 }
               }
+            }
+          },
+          {
+            name: 'pagination.defaultPageSize',
+            title: {
+              label: '默认每页条数',
+              tip: 'pagination.defaultPageSize | 默认每页条数'
+            },
+            propType: 'number',
+            setter: 'NumberSetter',
+            condition: {
+              type: 'JSFunction',
+              value: 'target => !!target.getProps().getPropValue("pagination")'
             }
           },
           {
@@ -640,7 +653,8 @@ const ProTableMeta = {
             condition: {
               type: 'JSFunction',
               value: 'target => !!target.getProps().getPropValue("pagination")'
-            }
+            },
+            supportVariable: true
           },
           // {
           //   name: 'pagination.total',

--- a/packages/antd-materials/lowcode/pro-table/snippets.ts
+++ b/packages/antd-materials/lowcode/pro-table/snippets.ts
@@ -158,7 +158,7 @@ export const snippets: Snippet[] = [
         ],
         rowKey: 'id',
         pagination: {
-          pageSize: 10
+          defaultPageSize: 10
         },
         search: {
           defaultCollapsed: false,
@@ -216,7 +216,7 @@ export const snippets: Snippet[] = [
         columns: getColumns(),
         rowKey: 'id',
         pagination: {
-          pageSize: 10
+          defaultPageSize: 10
         },
         search: {
           defaultCollapsed: false,
@@ -240,7 +240,7 @@ export const snippets: Snippet[] = [
         columns: getColumns(),
         rowKey: 'id',
         pagination: {
-          pageSize: 10
+          defaultPageSize: 10
         },
         expandable: {
           expandedRowRender: {


### PR DESCRIPTION
目前设置固定页码后切换页码 pagesize不可控，导致切换页数失效，若想pagesize可控需要单独给pagesize绑定state。
现在增加defaultPageSize选项，并设置默认defaultPageSize为10，满足用户设置默认页码大小的时候，使pagesize可控。切换页码不需要额外代码。