### PR TITLE
ProTable toolbar区域能力扩展

### DIFF
--- a/packages/antd-materials/lowcode/pro-table/meta.ts
+++ b/packages/antd-materials/lowcode/pro-table/meta.ts
@@ -1190,6 +1190,15 @@ const ProTableMeta = {
         type: 'group',
         items: [
           {
+            name: 'toolBarRenderOpen',
+            title: {
+              label: '启用工具栏',
+              tip: 'toolBarRenderOpen | 是否启用工具栏',
+            },
+            propType: 'bool',
+            setter: 'BoolSetter',
+          },
+          {
             name: 'toolBarRender',
             title: { label: '工具栏操作', tip: 'toolbar | 工具栏操作' },
             propType: 'func',
@@ -1200,18 +1209,48 @@ const ProTableMeta = {
                 initialValue: {
                   type: 'JSSlot',
                   params: ['currentPageData'],
-                  value: []
-                }
+                  value: [],
+                },
               },
               {
                 componentName: 'FunctionSetter',
                 props: {
                   template:
-                    'renderToolBar(currentPageData,${extParams}){\n// 自定义渲染表格顶部\nreturn "表格顶部";\n}'
-                }
+                    'renderToolBar(currentPageData,${extParams}){\n// 自定义渲染表格顶部\nreturn "表格顶部";\n}',
+                },
               },
-              'VariableSetter'
-            ]
+              'VariableSetter',
+            ],
+            condition: {
+              type: 'JSFunction',
+              value: 'target => !!target.getProps().getPropValue("toolBarRenderOpen")',
+            },
+          },
+          {
+            name: 'toolbar.title',
+            title: {
+              label: '标题',
+              tip: 'toolbar.title | 自定义标题',
+            },
+            propType: 'string',
+            setter: 'StringSetter',
+            condition: {
+              type: 'JSFunction',
+              value: 'target => !!target.getProps().getPropValue("toolBarRenderOpen")',
+            },
+          },
+          {
+            name: 'toolbar.subTitle',
+            title: {
+              label: '子标题',
+              tip: 'toolbar.subTitle | 自定义子标题',
+            },
+            propType: 'string',
+            setter: 'StringSetter',
+            condition: {
+              type: 'JSFunction',
+              value: 'target => !!target.getProps().getPropValue("toolBarRenderOpen")',
+            },
           },
           {
             name: 'title',

--- a/packages/antd-materials/src/components/ProTable/pro-table.tsx
+++ b/packages/antd-materials/src/components/ProTable/pro-table.tsx
@@ -79,7 +79,7 @@ class ProTable extends Component<IProTableProps, any> {
   }
 
   render() {
-    const { columns, rowSelection, intl, onValuesChange } = this.props
+    const { columns, rowSelection, intl, onValuesChange, toolBarRender, toolBarRenderOpen } = this.props
 
     const { selectedRowKeys, collapsed } = this.state
 
@@ -110,6 +110,18 @@ class ProTable extends Component<IProTableProps, any> {
     if (typeof pagination?.total === 'number') {
       delete pagination.total
     }
+    
+    const toolBarRenderFunc = () => {
+      if (toolBarRenderOpen) {
+        if (toolBarRender === false) {
+          return null;
+        } else {
+          return toolBarRender;
+        }
+      } else {
+        return false;
+      }
+    };
 
     return (
       <ConfigProvider locale={intlMap[intl || 'zhCNIntl']}>
@@ -150,6 +162,7 @@ class ProTable extends Component<IProTableProps, any> {
           actionRef={this.actionRef}
           formRef={this.formRef}
           form={{ onValuesChange: onValuesChange }}
+          toolBarRender={toolBarRenderFunc()}
         />
       </ConfigProvider>
     )


### PR DESCRIPTION
现有ProTable中toolbar能力尚不完整，主标题和副标题部分能力未放开。新增工具栏打开选项，集成原有的工具栏操作，新增左侧主副标题能力。