### PR TITLE
monaco插件加载资源，支持自定义cdn地址

### DIFF
--- a/packages/antd-setters/src/setters/FormilySchemaSetter/components/MonacoInput/format.ts
+++ b/packages/antd-setters/src/setters/FormilySchemaSetter/components/MonacoInput/format.ts
@@ -15,12 +15,22 @@ const cache: { prettier: Promise<IPrettierModule> } = {
   prettier: null
 }
 
+/**
+ * global prettierUrl
+ */
+let prettierUrl = '//cdn.jsdelivr.net/npm/prettier@2.x/esm/standalone.mjs'
+
+/**
+ * set global prettierUrl
+ * @param u
+ */
+export const setPrettierUrl = (u: string) => {
+  prettierUrl = u
+}
+
 export const format = async (language: string, source: string) => {
   cache.prettier =
-    cache.prettier ||
-    new Function(
-      `return import("//cdn.jsdelivr.net/npm/prettier@2.x/esm/standalone.mjs")`
-    )()
+    cache.prettier || new Function(`return import("${prettierUrl}")`)()
   return cache.prettier.then((module) => {
     if (
       language === 'javascript.expression' ||

--- a/packages/antd-setters/src/setters/FormilySchemaSetter/components/MonacoInput/index.tsx
+++ b/packages/antd-setters/src/setters/FormilySchemaSetter/components/MonacoInput/index.tsx
@@ -7,7 +7,7 @@ import { Tooltip } from 'antd'
 import { parseExpression, parse } from '@babel/parser'
 import { uid } from '../../utils'
 import { Help as HelpIcon } from '../../icons'
-import { format } from './format'
+import { format, setPrettierUrl } from './format'
 import cls from 'classnames'
 import './styles.less'
 import './config'
@@ -20,6 +20,10 @@ export interface MonacoInputProps extends EditorProps {
   helpCodeViewWidth?: number | string
   extraLib?: string
   onChange?: (value: string) => void
+  /**
+   * custom prettier resource
+   */
+  prettierUrl?: string
 }
 
 export const MonacoInput: React.FC<MonacoInputProps> & {
@@ -36,6 +40,7 @@ export const MonacoInput: React.FC<MonacoInputProps> & {
   onMount,
   onChange,
   theme = 'light',
+  prettierUrl,
   ...props
 }) => {
   const [loaded, setLoaded] = useState(false)
@@ -53,6 +58,12 @@ export const MonacoInput: React.FC<MonacoInputProps> & {
   const uidRef = useRef(uid())
   const prefix = 'dn-monaco-input'
   const input = props.value || props.defaultValue
+
+  useEffect(() => {
+    if (prettierUrl) {
+      setPrettierUrl(prettierUrl)
+    }
+  }, [prettierUrl])
 
   useEffect(() => {
     unmountedRef.current = false

--- a/packages/antd-setters/src/setters/FormilySchemaSetter/components/ReactionsSetter/index.tsx
+++ b/packages/antd-setters/src/setters/FormilySchemaSetter/components/ReactionsSetter/index.tsx
@@ -5,7 +5,7 @@ import { createSchemaField } from '@formily/react'
 import { GlobalRegistry } from '../../registry'
 import { requestIdle } from '../../utils'
 import { TextWidget } from '../TextWidget'
-import { MonacoInput } from '../MonacoInput'
+import { MonacoInput, MonacoInputProps } from '../MonacoInput'
 import {
   Form,
   ArrayTable,
@@ -26,6 +26,10 @@ import './styles.less'
 export interface IReactionsSetterProps {
   value?: IReaction
   onChange?: (value: IReaction) => void
+  initProps?: {
+    libraryDomain?: string
+    prettierUrl?: MonacoInputProps['prettierUrl']
+  }
 }
 
 const TypeView = ({ value }) => {
@@ -156,7 +160,7 @@ export const ReactionsSetter: React.FC<IReactionsSetterProps> = (props) => {
     if (modalVisible) {
       requestIdle(
         () => {
-          initDeclaration().then(() => {
+          initDeclaration(props?.initProps).then(() => {
             setInnerVisible(true)
           })
         },
@@ -413,7 +417,8 @@ export const ReactionsSetter: React.FC<IReactionsSetterProps> = (props) => {
                           minimap: {
                             enabled: false
                           }
-                        }
+                        },
+                        prettierUrl: props?.initProps?.prettierUrl
                       }}
                       x-reactions={(field) => {
                         const deps = field.query('dependencies').value()


### PR DESCRIPTION
内部过度依赖阿里的cdn和jsdelivr，导致加载资源速度不稳定,首页白屏时间过长，传入自定义cdn地址以增加资源的加载速度